### PR TITLE
change up authorization API to connection object

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -10,7 +10,8 @@ import servicepytan
 # Create the Jobs Endpoint Object
 # API Endpoint: https://api.servicetitan.io/jpm/v2/tenant/{tenant}/jobs
 # Folder: jpm, Endpoint: jobs
-st_jobs_endpoint = servicepytan.Endpoint("jpm", "jobs")
+st_conn = servicepytan.auth.servicepytan_connect(config_file="./servicepytan_config.json")
+st_jobs_endpoint = servicepytan.Endpoint("jpm", "jobs", conn=st_conn)
 
 options = {
   "pageSize":"50", # Number of jobs to return per API Request
@@ -35,8 +36,8 @@ print(f"Number of Jobs Returned: {len(jobs_data)}")
 
 ```python
 import servicepytan
-
-st_data_service = servicepytan.DataService()
+st_conn = servicepytan.auth.servicepytan_connect(config_file="./servicepytan_config.json")
+st_data_service = servicepytan.DataService(conn=st_conn)
 
 data = st_data_service.get_jobs_completed_between("2022-04-06", "2022-04-07")
 
@@ -46,23 +47,23 @@ print(f"Number of Jobs Returned {len(data)}")
 ## Custom Reports
 ```python
 # Import the functions and reporting class
-from servicepytan import Report
+from servicepytan import Report, auth
 from servicepytan.reports import get_report_categories, get_report_list
 
 # Set your config file path
-config_file_path = "./path/to/servicepytan_config.json"
+st_conn = servicepytan.auth.servicepytan_connect(config_file="./servicepytan_config.json")
 
 # Retrieve a list of report categories
-categories = get_report_categories(config_file_path)
+categories = get_report_categories(config_file_path, conn=st_conn)
 print(categories)
 
 # Retrieve a list of reports included in the category 
-category_report_list = get_report_list("operations", config_file_path)
+category_report_list = get_report_list("operations", config_file_path, conn=st_conn)
 print(category_report_list)
 
 # Configure a specific report
 # NOTE: this is a standard ServiceTitan report in the Operations category
-custom_report = Report("operations", "94428310", config_file=config_file_path)
+custom_report = Report("operations", "94428310", conn=st_conn)
 
 # Look at the reporting metadata
 # This inclued the filter options and field information
@@ -78,7 +79,7 @@ custom_report.show_param_types()
 # [ ] - IncludeAdjustmentInvoices: Boolean, 
 
 # Get dynamic set information if needed
-dynamic_sets = get_dynamic_set_list(dynamic_set_id='job-date-filter-type',config_file_path)
+dynamic_sets = get_dynamic_set_list(dynamic_set_id='job-date-filter-type',conn=st_conn)
 print(dynamic_sets)
 # [0, 'Invoice Date'],
 # [1, 'Job Completion Date'],

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,22 +41,27 @@ Create Configuration File
 Create your :code:`servicepytan_config.json` file in the root directory::
    
    {
-      "CLIENT_ID": "cid.hhmdjd1jk9nqwertyr5cl6t5u5r5",
-      "CLIENT_SECRET": "cs2.yjnblmqpfiuzjyqwerty5gc28a35qabzo1qsss2l3fll5st64tgrxjxz",
-      "APP_ID": "12abc346skeg",
-      "APP_KEY": "ak1.qey12fgjhnch03lsm",
-      "TENANT_ID": "1234567890",
-      "TIMEZONE": ""
+      "SERVICETITAN_CLIENT_ID": "cid.hhmdjd1jk9nqwertyr5cl6t5u5r5",
+      "SERVICETITAN_CLIENT_SECRET": "cs2.yjnblmqpfiuzjyqwerty5gc28a35qabzo1qsss2l3fll5st64tgrxjxz",
+      "SERVICETITAN_APP_ID": "12abc346skeg",
+      "SERVICETITAN_APP_KEY": "ak1.qey12fgjhnch03lsm",
+      "SERVICETITAN_TENANT_ID": "1234567890",
+      "SERVICETITAN_TIMEZONE": ""
    }
+
+Starting with >=0.3.0 there are addtioanl configuration options available. See :doc:`ServicePytan Configuration <./configuration>` for more information.
+1. Create a .env file in the root directory of your project. This file will be used to store your environment variables.
+2. By directly inputing the credentials into the :code:`servicepytan.auth.servicepytan_connect()` file, you are storing your credentials in plain text. This is not recommended.
+> :code:`servicepytan.auth.servicepytan_connect(app_id="", app_key="", client_id="", client_secret="", tenant_id="", timezone="")`
 
 > NOTE: Remember to exclude this file from version control. (e.g. add to your :code:`.gitignore` file)
 
-* :code:`CLIENT_ID` - Find in :code:`Settings > Integrations > API Application Access > [App Name] > Edit`
-* :code:`CLIENT_SECRET` - Generated one time with :code:`CLIENT ID`
-* :code:`APP_ID` - Found in developers portal app definition
-* :code:`APP_KEY` - Found in developers portal app definition
-* :code:`TENANT_ID` - Found in developers portal app definition and integration settings
-* :code:`TIMEZONE` - (Optional) - Timezone Abbreviation like :code:`America/New_York` as listed at https://timezonedb.com/time-zones
+* :code:`SERVICETITAN_CLIENT_ID` - Find in :code:`Settings > Integrations > API Application Access > [App Name] > Edit`
+* :code:`SERVICETITAN_CLIENT_SECRET` - Generated one time with :code:`CLIENT ID`
+* :code:`SERVICETITAN_APP_ID` - Found in developers portal app definition
+* :code:`SERVICETITAN_APP_KEY` - Found in developers portal app definition
+* :code:`SERVICETITAN_TENANT_ID` - Found in developers portal app definition and integration settings
+* :code:`SERVICETITAN_TIMEZONE` - (Optional) - Timezone Abbreviation like :code:`America/New_York` as listed at https://timezonedb.com/time-zones
 
 Making Your First Request
 -------------------------
@@ -67,7 +72,12 @@ Making Your First Request
 
       # API Endpoint: https://api.servicetitan.io/jpm/v2/tenant/{tenant}/jobs
       # Folder: jpm, Endpoint: jobs
-      st_jobs_endpoint = servicepytan.Endpoint("jpm", "jobs")
+
+      # Create Connection Object. Note: This is a change from previous versions.
+      st_conn = servicepytan.auth.servicepytan_connect(config_file="./servicepytan_config.json")
+      
+      # Create API Object
+      st_jobs_endpoint = servicepytan.Endpoint("jpm", "jobs", conn=st_conn)
 
       # Return the data for a specific job in ServiceTitan
       # https://go.servicetitan.com/#/Job/Index/138517400

--- a/servicepytan/__init__.py
+++ b/servicepytan/__init__.py
@@ -15,7 +15,7 @@ on developer site.
 
 __author__ = """Elliot Palmer"""
 __email__ = 'elliot@ecoplumbers.com'
-__version__ = '0.1.0'
+__version__ = '0.3.0'
 
 # MODULES
 import requests

--- a/servicepytan/auth.py
+++ b/servicepytan/auth.py
@@ -2,9 +2,58 @@
 
 import requests
 import json
+import os
+from dotenv import load_dotenv
+
 from servicepytan import URL_ROOT, AUTH_ROOT
 
-def get_auth_token(client_id, client_secret):
+AUTH_VARIABLES = [
+    'SERVICETITAN_APP_KEY',
+    'SERVICETITAN_TENANT_ID',
+    'SERVICETITAN_CLIENT_ID',
+    'SERVICETITAN_CLIENT_SECRET',
+    'SERVICETITAN_APP_ID',
+    'SERVICETITAN_TIMEZONE'
+]
+
+def servicepytan_connect(
+    app_key:str=None, tenant_id:str=None, client_id:str=None, 
+    client_secret:str=None, app_id:str=None, timezone:str="UTC", config_file:str=None):
+    
+    auth_config_object = {
+            "SERVICETITAN_APP_KEY": app_key,
+            "SERVICETITAN_TENANT_ID": tenant_id,
+            "SERVICETITAN_CLIENT_ID": client_id,
+            "SERVICETITAN_CLIENT_SECRET": client_secret,
+            "SERVICETITAN_APP_ID": app_id,
+            "SERVICETITAN_TIMEZONE": timezone
+    }
+
+
+    # First check if the config_file is provided
+    if config_file:
+        print("Setting auth config from file...")
+        f = open(config_file)
+        creds = json.load(f)
+        for var in AUTH_VARIABLES:
+            auth_config_object[var] = creds.get(var, '')
+        f.close()
+
+    # If not, check if the environment variables are set
+    elif not app_key or not tenant_id or not client_id or not client_secret or not app_id:
+        load_dotenv()
+        print("Auth config not provided, loading from environment variables...")
+        for var in AUTH_VARIABLES:
+            auth_var = os.environ.get(var)
+            if auth_var:
+                auth_config_object[var] = auth_var
+            else:
+                print(f"Environment variable {var} not found or provided in function. Defualting to empty string.")
+                auth_config_object[var] = ''
+
+    return auth_config_object
+
+def request_auth_token(client_id, client_secret):
   """Fetches Auth Token.
 
   Retrieves authentication token for completing a request against the API
@@ -31,7 +80,7 @@ def get_auth_token(client_id, client_secret):
 
   return json.loads(response.text)
 
-def get_auth_token_by_file(config_file='servicepytan_config.json'):
+def get_auth_token(conn):
   """Fetches Auth Token using the config_file.
 
   Retrives the CLIENT_ID and CLIENT_SECRET entries from config_file.
@@ -46,14 +95,11 @@ def get_auth_token_by_file(config_file='servicepytan_config.json'):
       TBD
   """
   # Read File
-  f = open(config_file)
-  creds = json.load(f)
-  client_id = creds['CLIENT_ID']
-  client_secret = creds['CLIENT_SECRET']
-  f.close()
-  return get_auth_token(client_id, client_secret)["access_token"]
+  client_id = conn['SERVICETITAN_CLIENT_ID']
+  client_secret = conn['SERVICETITAN_CLIENT_SECRET']
+  return request_auth_token(client_id, client_secret)["access_token"]
 
-def get_app_key(config_file='servicepytan_config.json'):
+def get_app_key(conn):
   """Fetches App Key from the config_file.
 
   Retrives the APP_KEY entry from config_file.
@@ -67,13 +113,10 @@ def get_app_key(config_file='servicepytan_config.json'):
   Raises:
       TBD
   """
-  f = open(config_file)
-  creds = json.load(f)
-  app_key = creds['APP_KEY']
-  f.close()
+  app_key = conn['SERVICETITAN_APP_KEY']
   return app_key
 
-def get_tenant_id(config_file='servicepytan_config.json'):
+def get_tenant_id(conn):
   """Fetches Tenant ID from the config_file.
 
   Retrives the TENANT_ID entry from config_file.
@@ -87,13 +130,10 @@ def get_tenant_id(config_file='servicepytan_config.json'):
   Raises:
       TBD
   """
-  f = open(config_file)
-  creds = json.load(f)
-  tenant_id = creds['TENANT_ID']
-  f.close()
+  tenant_id = conn['SERVICETITAN_TENANT_ID']
   return tenant_id 
 
-def get_auth_headers(config_file='servicepytan_config.json'):
+def get_auth_headers(conn):
   """Generates the Authentication Headers for each API request
 
   Creates an object that includes the auth token and app key formatted to create the auth headers.
@@ -108,6 +148,6 @@ def get_auth_headers(config_file='servicepytan_config.json'):
       TBD
   """
   return {
-      "Authorization": get_auth_token_by_file(config_file),
-      "ST-App-Key": get_app_key(config_file)
+      "Authorization": get_auth_token(conn),
+      "ST-App-Key": get_app_key(conn)
   }

--- a/servicepytan/data.py
+++ b/servicepytan/data.py
@@ -10,12 +10,12 @@ class DataService:
   based on retrieving data between a date range.
 
   Attributes:
-      config_file: a string file path to the config file.
+      conn: a dictionary containing the credential config.
   """
-  def __init__(self, config_file="servicepytan_config.json"):
+  def __init__(self, conn=None):
     """Inits DataService with configuration file and authentication settings."""
-    self.config_file = config_file
-    self.timezone = get_timezone_by_file(config_file)
+    self.conn = conn
+    self.timezone = get_timezone_by_file(conn)
 
   def get_jobs_completed_between(self, start_date, end_date, job_status=["Completed","Scheduled","InProgress","Dispatched"]):
     """Retrieve all jobs completed between the start and end date"""

--- a/servicepytan/reports.py
+++ b/servicepytan/reports.py
@@ -1,17 +1,17 @@
 import math
 from servicepytan.utils import request_json, get_timezone_by_file, endpoint_url, request_json_with_retry
 
-def get_report_categories(config_file="servicepytan_config.json"):
+def get_report_categories(conn=None):
     """Get a list of report categories"""
-    return request_json(endpoint_url('reporting', 'report-categories', config_file=config_file), config_file=config_file)
+    return request_json(endpoint_url('reporting', 'report-categories', conn=conn), conn=conn)
 
-def get_report_list(report_category, config_file="servicepytan_config.json"):
+def get_report_list(report_category, conn=None):
     """Get a list of reports for a given report category"""
-    return request_json(endpoint_url('reporting', f'report-category/{report_category}/reports', config_file=config_file), config_file=config_file)
+    return request_json(endpoint_url('reporting', f'report-category/{report_category}/reports', conn=conn), conn=conn)
 
-def get_dynamic_set_list(dynamic_set_id,config_file="servicepytan_config.json"):
+def get_dynamic_set_list(dynamic_set_id,conn=None):
     """Get a list of dynamic sets"""
-    return request_json(endpoint_url('reporting', f'dynamic-value-sets/{dynamic_set_id}', config_file=config_file), config_file=config_file)
+    return request_json(endpoint_url('reporting', f'dynamic-value-sets/{dynamic_set_id}', conn=conn), conn=conn)
 
 class Report:
   """Primary class for retrieving Reporting Endpoint Data.
@@ -19,12 +19,12 @@ class Report:
   Attributes:
       category: A string representing the report category. Find list of categories with get_report_categories().
       report_id: A string representing the report id. Find list of report_id using get_report_list().
-      config_file: a string file path to the config file.
+      conn: a dictionary containing the credential config.
   """
-  def __init__(self, category, report_id, config_file="servicepytan_config.json"):
+  def __init__(self, category, report_id, conn=None):
     """Inits DataService with configuration file and authentication settings."""
-    self.config_file = config_file
-    self.timezone = get_timezone_by_file(config_file)
+    self.conn = conn
+    # self.timezone = get_timezone_by_file(conn)
     self.category = category
     self.report_id = report_id
     self.params = {"parameters": []}
@@ -55,8 +55,8 @@ class Report:
   def get_metadata(self):
     """get report metadata"""
     endpoint = f"report-category/{self.category}/reports/{self.report_id}"
-    url = endpoint_url("reporting",endpoint, config_file=self.config_file)
-    return request_json_with_retry(url, config_file=self.config_file)
+    url = endpoint_url("reporting",endpoint, conn=self.conn)
+    return request_json_with_retry(url, conn=self.conn)
 
   def show_param_types(self):
     """show parameter types"""
@@ -75,9 +75,9 @@ class Report:
       params = self.params
     options = {"page": page, "pageSize": page_size, "includeTotal": True}
     endpoint = f"report-category/{self.category}/reports/{self.report_id}/data"
-    url = endpoint_url("reporting",endpoint, config_file=self.config_file)
+    url = endpoint_url("reporting",endpoint, conn=self.conn)
     return request_json_with_retry(url, options=options, json_payload=params, 
-              config_file=self.config_file, request_type="POST")
+              conn=self.conn, request_type="POST")
   
   def get_all_data(self, params="", page_size=5000):
     """get all report data"""

--- a/servicepytan/requests.py
+++ b/servicepytan/requests.py
@@ -10,25 +10,25 @@ class Endpoint:
   Attributes:
       folder: A string indicating the group of endpoints you want to address.
       endpoint: A string indicating the endpoint you want to address.
-      config_file: a string file path to the config file.
+      conn: a dictionary containing the credential config.
   """
-  def __init__(self, folder, endpoint, config_file='servicepytan_config.json'):
+  def __init__(self, folder, endpoint, conn=None):
     """Inits Endpoint with folder, endpoint and allows for getting necessary credentials from the config file."""
     self.folder = folder
     self.endpoint = endpoint
-    self.config_file = config_file
+    self.conn = conn
 
   # Main Request Types
   def get_one(self, id, modifier=""):
     """Retrieve one record using the record id. Modifier is used for further endpoints."""
-    url = endpoint_url(self.folder, self.endpoint, id=id, modifier=modifier, config_file=self.config_file)
-    return request_json(url, options={}, payload="", config_file=self.config_file, request_type="GET")
+    url = endpoint_url(self.folder, self.endpoint, id=id, modifier=modifier, conn=self.conn)
+    return request_json(url, options={}, payload="", conn=self.conn, request_type="GET")
 
   def get_many(self, query={}):
     """Retrieve one page of results with query options to customize."""
-    url = endpoint_url(self.folder, self.endpoint, config_file=self.config_file)
+    url = endpoint_url(self.folder, self.endpoint, conn=self.conn)
     options = check_default_options(query)
-    return request_json(url, options, payload="", config_file=self.config_file, request_type="GET")
+    return request_json(url, options, payload="", conn=self.conn, request_type="GET")
   
   def get_all(self, query={}):
     """Retrive all pages in your query."""
@@ -49,28 +49,28 @@ class Endpoint:
 
   def create(self, payload):
     """Method that corresponds to a POST request for creating objects"""
-    url = endpoint_url(self.folder, self.endpoint, config_file=self.config_file)
-    return request_json(url, options={}, payload=payload, config_file=self.config_file, request_type="POST")
+    url = endpoint_url(self.folder, self.endpoint, conn=self.conn)
+    return request_json(url, options={}, payload=payload, conn=self.conn, request_type="POST")
 
   def update(self, id, payload, modifier="", request_type="PUT"):
     """Method that corresponds to PUT or POST request for updating objects. Defaults to PUT"""
-    url = endpoint_url(self.folder, self.endpoint, id=id, modifier=modifier, config_file=self.config_file)
-    return request_json(url, options={}, payload=payload, config_file=self.config_file, request_type=request_type)
+    url = endpoint_url(self.folder, self.endpoint, id=id, modifier=modifier, conn=self.conn)
+    return request_json(url, options={}, payload=payload, conn=self.conn, request_type=request_type)
 
   def delete(self, id, modifier=""):
     """Method that corresponds to a DEL request for deleting objects"""
-    url = endpoint_url(self.folder, self.endpoint, id=id, modifier=f"{modifier}", config_file=self.config_file)
-    return request_json(url, options={}, payload="", config_file=self.config_file, request_type="DEL")
+    url = endpoint_url(self.folder, self.endpoint, id=id, modifier=f"{modifier}", conn=self.conn)
+    return request_json(url, options={}, payload="", conn=self.conn, request_type="DEL")
 
   def delete_subitem(self, id, modifier_id, modifier):
     """Method that corresponds to a DEL request for deleting objects with subitems"""
-    url = endpoint_url(self.folder, self.endpoint, id=id, modifier=f"{modifier}/{modifier_id}", config_file=self.config_file)
-    return request_json(url, options={}, payload="", config_file=self.config_file, request_type="DEL")
+    url = endpoint_url(self.folder, self.endpoint, id=id, modifier=f"{modifier}/{modifier_id}", conn=self.conn)
+    return request_json(url, options={}, payload="", conn=self.conn, request_type="DEL")
 
   def export_one(self, export_endpoint, export_from=""):
     """Export Doc String"""
-    url = endpoint_url(self.folder, "export", id="", modifier=f"{export_endpoint}", config_file=self.config_file)
-    return request_json(url, options={"from": export_from}, payload="", config_file=self.config_file, request_type="GET")
+    url = endpoint_url(self.folder, "export", id="", modifier=f"{export_endpoint}", conn=self.conn)
+    return request_json(url, options={"from": export_from}, payload="", conn=self.conn, request_type="GET")
 
   def export_all(self, export_endpoint, export_from=""):
     """Export All Doc String"""

--- a/servicepytan/summary.py
+++ b/servicepytan/summary.py
@@ -1,6 +1,6 @@
 from servicepytan.data import DataService
 
-def get_booked_jobs_by_agent(start_date, end_date, config_file="servicepytan_config.json"):
-  booked_jobs = DataService(config_file=config_file).get_jobs_created_between(start_date, end_date)
-  employees = DataService(config_file=config_file).get_employees()
-  pass
+def get_booked_jobs_by_agent(start_date, end_date, conn=None):
+  booked_jobs = DataService(conn=conn).get_jobs_created_between(start_date, end_date)
+  employees = DataService(conn=conn).get_employees()
+  pass2

--- a/servicepytan/utils.py
+++ b/servicepytan/utils.py
@@ -5,7 +5,7 @@ import time
 from servicepytan import URL_ROOT, AUTH_ROOT
 from servicepytan.auth import get_auth_headers, get_tenant_id
 
-def request_json(url, options={}, payload="", config_file='servicepytan_config.json', request_type="GET", json_payload=""):
+def request_json(url, options={}, payload="", conn=None, request_type="GET", json_payload=""):
   """Makes the request to the API and returns JSON
 
   Retrieves JSON response from provided URL with a number of parameters to customize the request.
@@ -14,7 +14,7 @@ def request_json(url, options={}, payload="", config_file='servicepytan_config.j
       url: A string with the full URL request
       options: A dictionary defining the parameters to add to the url for filtering
       payload: A dictionary defining the data object to create or update
-      config_file: A string for the file path to the configuration file.
+      conn: a dictionary containing the credential config.
       request_type: A string to define the REST endpoint type [GET, POST, PUT, PATCH, DEL].
 
   Returns:
@@ -23,7 +23,7 @@ def request_json(url, options={}, payload="", config_file='servicepytan_config.j
   Raises:
       TBD
   """
-  headers = get_auth_headers(config_file)
+  headers = get_auth_headers(conn)
   response = requests.request(request_type, url, data=payload, headers=headers, params=options, json=json_payload)
   return json.loads(response.text)
 
@@ -35,7 +35,7 @@ def check_default_options(options):
   
   return options
 
-def endpoint_url(folder, endpoint, id="", modifier="", config_file='servicepytan_config.json', tenant_id=""):
+def endpoint_url(folder, endpoint, id="", modifier="", conn=None, tenant_id=""):
   """Constructs API request URL based on key parameters
 
   Retrives JSON response from provided URL with a number of parameters to customize the request.
@@ -45,7 +45,7 @@ def endpoint_url(folder, endpoint, id="", modifier="", config_file='servicepytan
       endpoint: A string indicating the endpoint you want to address.
       id: A string for the id of the endpoint object you're addressing.
       modifier: A string to modify the url to address the additional endpoint.
-      config_file: A string for the file path to the configuration file.
+      conn: a dictionary containing the credential config.
       tenant_id: A string to manually adjust the tenant id.
 
   Returns:
@@ -56,7 +56,7 @@ def endpoint_url(folder, endpoint, id="", modifier="", config_file='servicepytan
   """  
   # Adds ability to manually switch up the Tenant ID for apps that have multiples
   if tenant_id == "":
-    tenant_id = get_tenant_id(config_file)
+    tenant_id = get_tenant_id(conn)
 
   url = f"{URL_ROOT}/{folder}/v2/tenant/{tenant_id}/{endpoint}"
   if id != "": url = f"{url}/{id}"
@@ -67,7 +67,7 @@ def create_credential_file(name="servicepytan_config.json"):
   """Creates and saves an unfilled configuration file.
 
   Args:
-      name: A string path to the credentials file
+      name: a dictionary containing the credential config
 
   Returns:
       A filepath string
@@ -75,33 +75,30 @@ def create_credential_file(name="servicepytan_config.json"):
   file = open(name, 'w')
   file.write(
     """{
-    "CLIENT_ID": "",
-    "CLIENT_SECRET": "",
-    "APP_ID": "",
-    "APP_KEY": "",
-    "TENANT_ID": ""
+    "SERVICETITAN_CLIENT_ID": "",
+    "SERVICETITAN_CLIENT_SECRET": "",
+    "SERVICETITAN_APP_ID": "",
+    "SERVICETITAN_APP_KEY": "",
+    "SERVICETITAN_TENANT_ID": ""
     }"""
   )
   file.close()
   return name
 
-def get_timezone_by_file(config_file='servicepytan_config.json'):
+def get_timezone_by_file(conn=None):
   """Retrieves timezone from the configuration file.
 
   Args:
-      config_file: A string path to the credentials file
+      conn: a dictionary containing the credential config
 
   Returns:
       Timezone string
   """    
   # Read File
-  f = open(config_file)
-  config = json.load(f)
-  if "TIMEZONE" in config:
-    timezone = config['TIMEZONE']
+  if "SERVICETITAN_TIMEZONE" in conn:
+    timezone = config['SERVICETITAN_TIMEZONE']
   else:
-    timezone = ""
-  f.close()
+    timezone = "UTC"
   return timezone
 
 def sleep_with_countdown(sleep_time):
@@ -112,7 +109,7 @@ def sleep_with_countdown(sleep_time):
   print("")
   pass
 
-def request_json_with_retry(url, options={}, payload="", config_file='servicepytan_config.json', request_type="GET", json_payload=""):
+def request_json_with_retry(url, options={}, payload="", conn=None, request_type="GET", json_payload=""):
   """Makes the request to the API and returns JSON with a retry
 
   Retrieves JSON response from provided URL with a number of parameters to customize the request.
@@ -121,7 +118,7 @@ def request_json_with_retry(url, options={}, payload="", config_file='servicepyt
       url: A string with the full URL request
       options: A dictionary defining the parameters to add to the url for filtering
       payload: A dictionary defining the data object to create or update
-      config_file: A string for the file path to the configuration file.
+      conn: a dictionary containing the credential config.
       request_type: A string to define the REST endpoint type [GET, POST, PUT, PATCH, DEL].
       retry_count: An integer for the number of times to retry the request.
       sleep_time: An integer for the number of seconds to sleep between retries.
@@ -132,12 +129,12 @@ def request_json_with_retry(url, options={}, payload="", config_file='servicepyt
   Raises:
       TBD
   """
-  response = request_json(url, options=options, payload=payload, config_file=config_file, request_type=request_type, json_payload=json_payload)
+  response = request_json(url, options=options, payload=payload, conn=conn, request_type=request_type, json_payload=json_payload)
   if "traceId" in response:
     if response['status'] == 429:
         sleep_time = response['title'].split(" ")[-2]
         print("Rate Limit Exceeded. Retrying in {} seconds...".format(sleep_time))
         sleep_with_countdown(int(sleep_time))
-        response = request_json_with_retry(url, options=options, payload=payload, config_file=config_file, request_type=request_type, json_payload=json_payload)
+        response = request_json_with_retry(url, options=options, payload=payload, conn=conn, request_type=request_type, json_payload=json_payload)
   
   return response

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.2
+current_version = 0.3.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['Click>=7.0', 'requests', 'python-dateutil', 'pytz',]
+requirements = ['Click>=7.0', 'requests', 'python-dateutil', 'pytz','python-dotenv','pyyaml']
 
 test_requirements = [ ]
 
@@ -44,6 +44,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/elliotpalmer/servicepytan',
-    version='0.2.2',
+    version='0.3.0',
     zip_safe=False,
 )


### PR DESCRIPTION
Major breaking change to the previous API. Moving from only using the .json configuration file method and config_file parameter to creating a connection object.

New Connection Methods
```python

from servicepytan import auth

st_conn = auth.servicepytan_connection() # To pull from .env or environment variables
st_conn = auth.servicepytan_connection(config_file="./servicepytan_config.json") # from json config
st_conn = auth.servicepytan_connection(app_id="23kdadlfbe.dks",...)

```