### PR TITLE
Added ability to configure the connection for either Production or Integration

### DIFF
--- a/servicepytan/__init__.py
+++ b/servicepytan/__init__.py
@@ -21,10 +21,6 @@ __version__ = '0.3.2'
 import requests
 import json
 
-# GLOBALS
-AUTH_ROOT = "https://auth.servicetitan.io"
-URL_ROOT = "https://api.servicetitan.io"
-
 from servicepytan.requests import Endpoint
 from servicepytan.reports import Report
 from servicepytan.data import DataService

--- a/servicepytan/auth.py
+++ b/servicepytan/auth.py
@@ -105,7 +105,6 @@ def request_auth_token(auth_root_url: str, client_id, client_secret):
     "client_secret": client_secret,
   }
 
-  print(f"Requesting auth token from {url} with headers {headers} and data {data}")
   response = requests.post(url, headers=headers, data=data)
   if response.status_code != requests.codes.ok:
     print(f"Error fetching auth token (url={url}, header={headers}, data={data}): {response.text}")

--- a/servicepytan/auth.py
+++ b/servicepytan/auth.py
@@ -94,19 +94,23 @@ def request_auth_token(auth_root_url: str, client_id, client_secret):
       TBD
   """
 
-  url = f"{auth_root_url}/connect/token"
+  url: str = f"{auth_root_url}/connect/token"
 
-  querystring = {"Content-Type":"application/x-www-form-urlencoded"}
+  headers: dict = {
+    "Content-Type": "application/x-www-form-urlencoded",
+  }
+  data: dict = {
+    "grant_type": "client_credentials",
+    "client_id": client_id,
+    "client_secret": {client_secret}
+  }
 
-  payload = f"grant_type=client_credentials&client_id={client_id}&client_secret={client_secret}"
-  headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-  response = requests.request("POST", url, data=payload, headers=headers, params=querystring)
+  response = requests.post(url, headers=headers, data=data)
   if response.status_code != requests.codes.ok:
-    print(f"Error fetching auth token (url={url}, payload={payload}, headers={headers}, querystring={querystring}): {response.text}")
+    print(f"Error fetching auth token (url={url}, header={headers}, data={data}): {response.text}")
     response.raise_for_status()
 
-  return json.loads(response.text)
+  return response.json()
 
 def get_auth_token(conn):
   """Fetches Auth Token using the config_file.

--- a/servicepytan/auth.py
+++ b/servicepytan/auth.py
@@ -102,9 +102,10 @@ def request_auth_token(auth_root_url: str, client_id, client_secret):
   data: dict = {
     "grant_type": "client_credentials",
     "client_id": client_id,
-    "client_secret": {client_secret}
+    "client_secret": client_secret,
   }
 
+  print(f"Requesting auth token from {url} with headers {headers} and data {data}")
   response = requests.post(url, headers=headers, data=data)
   if response.status_code != requests.codes.ok:
     print(f"Error fetching auth token (url={url}, header={headers}, data={data}): {response.text}")

--- a/servicepytan/auth.py
+++ b/servicepytan/auth.py
@@ -102,6 +102,9 @@ def request_auth_token(auth_root_url: str, client_id, client_secret):
   headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
   response = requests.request("POST", url, data=payload, headers=headers, params=querystring)
+  if response.status_code != requests.codes.ok:
+    print(f"Error fetching auth token: {response.text}")
+    response.raise_for_status()
 
   return json.loads(response.text)
 

--- a/servicepytan/auth.py
+++ b/servicepytan/auth.py
@@ -47,7 +47,7 @@ AUTH_VARIABLES = [
 ]
 
 def servicepytan_connect(
-    api_environment: str,
+    api_environment: str=ApiEnvironment.production,
     app_key:str=None, tenant_id:str=None, client_id:str=None, 
     client_secret:str=None, app_id:str=None, timezone:str="UTC", config_file:str=None):
     

--- a/servicepytan/auth.py
+++ b/servicepytan/auth.py
@@ -40,7 +40,8 @@ def servicepytan_connect(
         f.close()
 
     # If not, check if the environment variables are set
-    elif not app_key or not tenant_id or not client_id or not client_secret or not app_id:
+    # AFAICT, app_id is never used in the rest of the code, so it isn't necessary
+    elif not app_key or not tenant_id or not client_id or not client_secret:
         load_dotenv()
         print("Auth config not provided, loading from environment variables...")
         for var in AUTH_VARIABLES:

--- a/servicepytan/auth.py
+++ b/servicepytan/auth.py
@@ -40,17 +40,17 @@ def servicepytan_connect(
     client_secret:str=None, app_id:str=None, timezone:str="UTC", config_file:str=None):
     
     auth_config_object = {
-            "SERVICETITAN_APP_KEY": app_key,
-            "SERVICETITAN_TENANT_ID": tenant_id,
-            "SERVICETITAN_CLIENT_ID": client_id,
-            "SERVICETITAN_CLIENT_SECRET": client_secret,
-            "SERVICETITAN_APP_ID": app_id,
-            "SERVICETITAN_TIMEZONE": timezone,
+        "SERVICETITAN_APP_KEY": app_key,
+        "SERVICETITAN_TENANT_ID": tenant_id,
+        "SERVICETITAN_CLIENT_ID": client_id,
+        "SERVICETITAN_CLIENT_SECRET": client_secret,
+        "SERVICETITAN_APP_ID": app_id,
+        "SERVICETITAN_TIMEZONE": timezone,
 
-            'SERVICETITAN_API_ENVIRONMENT': api_environment,
+        'SERVICETITAN_API_ENVIRONMENT': api_environment,
 
-            "auth_root": get_auth_root_url(api_environment),
-            "api_root": get_api_root_url(api_environment),
+        "auth_root": get_auth_root_url(api_environment),
+        "api_root": get_api_root_url(api_environment),
     }
 
 

--- a/servicepytan/auth.py
+++ b/servicepytan/auth.py
@@ -103,7 +103,7 @@ def request_auth_token(auth_root_url: str, client_id, client_secret):
 
   response = requests.request("POST", url, data=payload, headers=headers, params=querystring)
   if response.status_code != requests.codes.ok:
-    print(f"Error fetching auth token: {response.text}")
+    print(f"Error fetching auth token (url={url}, payload={payload}, headers={headers}, querystring={querystring}): {response.text}")
     response.raise_for_status()
 
   return json.loads(response.text)

--- a/servicepytan/requests.py
+++ b/servicepytan/requests.py
@@ -1,4 +1,10 @@
 from servicepytan.utils import request_json, check_default_options, endpoint_url
+
+import logging
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
 class Endpoint:
   """Primary class for interacting with the API by establishing an endpoint object.
 
@@ -40,14 +46,14 @@ class Endpoint:
   def get_all(self, query={}, id="", modifier=""):
     """Retrive all pages in your query."""
     query["page"] = "1"
-    print(query)
+    logger.info(query)
     response = self.get_many(query=query, id=id, modifier=modifier)
     data = response["data"]
     if data == []: return []
     has_more = response["hasMore"]
     while has_more:
       query["page"] = str(int(query["page"]) + 1)
-      print(query)
+      logger.info(query)
       response = self.get_many(query=query, id=id, modifier=modifier)
       data.extend(response["data"])
       has_more = response["hasMore"]
@@ -82,7 +88,7 @@ class Endpoint:
   def export_all(self, export_endpoint, export_from="", include_recent_changes=False):
     """Export All Doc String"""
     counter = 1
-    print(f"{export_endpoint} {counter}: {export_from}")
+    logger.info(f"{export_endpoint} {counter}: {export_from}")
     response = self.export_one(export_endpoint, export_from, include_recent_changes)
     data = response["data"]
     if data == []: return []
@@ -90,9 +96,9 @@ class Endpoint:
     while has_more:
       counter += 1
       export_from = response["continueFrom"]
-      print(f"{export_endpoint} {counter}: {export_from}")
+      logger.info(f"{export_endpoint} {counter}: {export_from}")
       response = self.export_one(export_endpoint, export_from, include_recent_changes)
       data.extend(response["data"])
       has_more = response["hasMore"]
-    print(f"Export Data Complete. {len(data)} rows exported.")
+    logger.info(f"Export Data Complete. {len(data)} rows exported.")
     return data

--- a/servicepytan/requests.py
+++ b/servicepytan/requests.py
@@ -25,24 +25,30 @@ class Endpoint:
     options = check_default_options(query)
     return request_json(url, options=options, payload="", conn=self.conn, request_type="GET")
 
-  def get_many(self, query={}):
-    """Retrieve one page of results with query options to customize."""
-    url = endpoint_url(self.folder, self.endpoint, conn=self.conn)
+  def get_many(self, query={}, id="", modifier=""):
+    """
+    Retrieve one page of results with query options to customize.
+
+    Even though this is a "get_many" request, we can still use an id and modifier.
+    For example, this is how we get Notes for a specific Job.
+    The id would be the Job ID and the modifier would be "notes".
+    """
+    url = endpoint_url(self.folder, self.endpoint, id=id, modifier=modifier, conn=self.conn)
     options = check_default_options(query)
     return request_json(url, options, payload="", conn=self.conn, request_type="GET")
   
-  def get_all(self, query={}):
+  def get_all(self, query={}, id="", modifier=""):
     """Retrive all pages in your query."""
     query["page"] = "1"
     print(query)
-    response = self.get_many(query)
+    response = self.get_many(query=query, id=id, modifier=modifier)
     data = response["data"]
     if data == []: return []
     has_more = response["hasMore"]
     while has_more:
       query["page"] = str(int(query["page"]) + 1)
       print(query)
-      response = self.get_many(query)
+      response = self.get_many(query=query, id=id, modifier=modifier)
       data.extend(response["data"])
       has_more = response["hasMore"]
 

--- a/servicepytan/summary.py
+++ b/servicepytan/summary.py
@@ -3,4 +3,4 @@ from servicepytan.data import DataService
 def get_booked_jobs_by_agent(start_date, end_date, conn=None):
   booked_jobs = DataService(conn=conn).get_jobs_created_between(start_date, end_date)
   employees = DataService(conn=conn).get_employees()
-  pass2
+  pass

--- a/servicepytan/utils.py
+++ b/servicepytan/utils.py
@@ -2,7 +2,6 @@
 import requests
 import json
 import time
-from servicepytan import URL_ROOT, AUTH_ROOT
 from servicepytan.auth import get_auth_headers, get_tenant_id
 
 def request_json(url, options={}, payload="", conn=None, request_type="GET", json_payload=""):
@@ -58,7 +57,7 @@ def endpoint_url(folder, endpoint, id="", modifier="", conn=None, tenant_id=""):
   if tenant_id == "":
     tenant_id = get_tenant_id(conn)
 
-  url = f"{URL_ROOT}/{folder}/v2/tenant/{tenant_id}/{endpoint}"
+  url = f"{conn['api_root']}/{folder}/v2/tenant/{tenant_id}/{endpoint}"
   if id != "": url = f"{url}/{id}"
   if modifier != "": url = f"{url}/{modifier}"
   return url

--- a/servicepytan/utils.py
+++ b/servicepytan/utils.py
@@ -1,10 +1,9 @@
 """Utility Functions for Supporting Other Modules"""
 import requests
-import json
 import time
 from servicepytan.auth import get_auth_headers, get_tenant_id
 
-def request_json(url, options={}, payload="", conn=None, request_type="GET", json_payload=""):
+def request_json(url, options={}, payload={}, conn=None, request_type="GET", json_payload={}):
   """Makes the request to the API and returns JSON
 
   Retrieves JSON response from provided URL with a number of parameters to customize the request.
@@ -25,10 +24,10 @@ def request_json(url, options={}, payload="", conn=None, request_type="GET", jso
   headers = get_auth_headers(conn)
   response = requests.request(request_type, url, data=payload, headers=headers, params=options, json=json_payload)
   if response.status_code != requests.codes.ok:
-    print(f"Error fetching data (url={url}, data={payload}, headers={headers}, json={json_payload}): {response.text}")
+    print(f"Error fetching data (url={url}, heads={headers}, data={payload}, json={json_payload}): {response.text}")
     response.raise_for_status()
 
-  return json.loads(response.text)
+  return response.json()
 
 def check_default_options(options):
   """Add sensible defaults to options when not defined"""

--- a/servicepytan/utils.py
+++ b/servicepytan/utils.py
@@ -24,6 +24,10 @@ def request_json(url, options={}, payload="", conn=None, request_type="GET", jso
   """
   headers = get_auth_headers(conn)
   response = requests.request(request_type, url, data=payload, headers=headers, params=options, json=json_payload)
+  if response.status_code != requests.codes.ok:
+    print(f"Error fetching data at {url}: {response.text}")
+    response.raise_for_status()
+
   return json.loads(response.text)
 
 def check_default_options(options):

--- a/servicepytan/utils.py
+++ b/servicepytan/utils.py
@@ -25,7 +25,7 @@ def request_json(url, options={}, payload="", conn=None, request_type="GET", jso
   headers = get_auth_headers(conn)
   response = requests.request(request_type, url, data=payload, headers=headers, params=options, json=json_payload)
   if response.status_code != requests.codes.ok:
-    print(f"Error fetching data at {url}: {response.text}")
+    print(f"Error fetching data (url={url}, data={payload}, headers={headers}, json={json_payload}): {response.text}")
     response.raise_for_status()
 
   return json.loads(response.text)

--- a/servicepytan/utils.py
+++ b/servicepytan/utils.py
@@ -3,6 +3,11 @@ import requests
 import time
 from servicepytan.auth import get_auth_headers, get_tenant_id
 
+import logging
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
 def request_json(url, options={}, payload={}, conn=None, request_type="GET", json_payload={}):
   """Makes the request to the API and returns JSON
 
@@ -24,7 +29,7 @@ def request_json(url, options={}, payload={}, conn=None, request_type="GET", jso
   headers = get_auth_headers(conn)
   response = requests.request(request_type, url, data=payload, headers=headers, params=options, json=json_payload)
   if response.status_code != requests.codes.ok:
-    print(f"Error fetching data (url={url}, heads={headers}, data={payload}, json={json_payload}): {response.text}")
+    logger.error(f"Error fetching data (url={url}, heads={headers}, data={payload}, json={json_payload}): {response.text}")
     response.raise_for_status()
 
   return response.json()
@@ -106,9 +111,9 @@ def get_timezone_by_file(conn=None):
 def sleep_with_countdown(sleep_time):
   """Sleeps for a given amount of time with a countdown"""
   for i in range(sleep_time, 0, -1):
-      print("Trying again in {} seconds...       ".format(i),end='\r')
+      logger.info("Trying again in {} seconds...       ".format(i),end='\r')
       time.sleep(1)
-  print("")
+  logger.info("")
   pass
 
 def request_json_with_retry(url, options={}, payload="", conn=None, request_type="GET", json_payload=""):
@@ -135,7 +140,7 @@ def request_json_with_retry(url, options={}, payload="", conn=None, request_type
   if "traceId" in response:
     if response['status'] == 429:
         sleep_time = response['title'].split(" ")[-2]
-        print("Rate Limit Exceeded. Retrying in {} seconds...".format(sleep_time))
+        logger.warning("Rate Limit Exceeded. Retrying in {} seconds...".format(sleep_time))
         sleep_with_countdown(int(sleep_time))
         response = request_json_with_retry(url, options=options, payload=payload, conn=conn, request_type=request_type, json_payload=json_payload)
   


### PR DESCRIPTION
- Added the `ApiEnvironment` enum in `auth.py` to indicate whether to connect to ServiceTitan production or integration.
- Added `api_environment` as an argument to `servicepytan_connect` with a default value of `ApiEnvironment.production`.
- Replaced `json.loads(response.text)` with the build-in `response.json()`.
- Added error logging when network calls fail.
- Replaced calls to `print` with calls to `logger`.